### PR TITLE
use version commit instead of PR head commit

### DIFF
--- a/in.go
+++ b/in.go
@@ -41,15 +41,15 @@ func Get(request GetRequest, github Github, git Git, outputDir string) (*GetResp
 
 	switch tool := request.Params.IntegrationTool; tool {
 	case "rebase":
-		if err := git.Rebase(pull.BaseRefName, pull.HeadRef.OID); err != nil {
+		if err := git.Rebase(pull.BaseRefName, request.Version.Commit); err != nil {
 			return nil, err
 		}
 	case "merge", "":
-		if err := git.Merge(pull.HeadRef.OID); err != nil {
+		if err := git.Merge(request.Version.Commit); err != nil {
 			return nil, err
 		}
 	case "checkout":
-		if err := git.Checkout(pull.HeadRefName, pull.HeadRef.OID); err != nil {
+		if err := git.Checkout(pull.HeadRefName, request.Version.Commit); err != nil {
 			return nil, err
 		}
 	default:

--- a/in_test.go
+++ b/in_test.go
@@ -222,18 +222,18 @@ func TestGet(t *testing.T) {
 				if assert.Equal(t, 1, git.RebaseCallCount()) {
 					branch, tip := git.RebaseArgsForCall(0)
 					assert.Equal(t, tc.pullRequest.BaseRefName, branch)
-					assert.Equal(t, tc.pullRequest.HeadRef.OID, tip)
+					assert.Equal(t, tc.version.Commit, tip)
 				}
 			case "checkout":
 				if assert.Equal(t, 1, git.CheckoutCallCount()) {
 					branch, sha := git.CheckoutArgsForCall(0)
 					assert.Equal(t, tc.pullRequest.HeadRefName, branch)
-					assert.Equal(t, tc.pullRequest.HeadRef.OID, sha)
+					assert.Equal(t, tc.version.Commit, sha)
 				}
 			default:
 				if assert.Equal(t, 1, git.MergeCallCount()) {
 					tip := git.MergeArgsForCall(0)
-					assert.Equal(t, tc.pullRequest.HeadRef.OID, tip)
+					assert.Equal(t, tc.version.Commit, tip)
 				}
 			}
 			if tc.source.GitCryptKey != "" {


### PR DESCRIPTION
the head commit may have changed since the build was scheduled, so use
version commit sha instead