### PR TITLE
get logic tweaks

### DIFF
--- a/git.go
+++ b/git.go
@@ -145,8 +145,13 @@ func (g *GitClient) RevParse(branch string) (string, error) {
 }
 
 // Fetch ...
-func (g *GitClient) Fetch(prNumber int, depth int) error {
-	args := []string{"fetch", "origin", fmt.Sprintf("pull/%s/head", strconv.Itoa(prNumber))}
+func (g *GitClient) Fetch(prNumber, depth int) error {
+	args := []string{
+		"fetch",
+		"origin",
+		"-q",
+		fmt.Sprintf("pull/%s/head", strconv.Itoa(prNumber)),
+	}
 	args = appendDepth(args, depth)
 	cmd := g.command("git", args...)
 
@@ -164,8 +169,8 @@ func (g *GitClient) Fetch(prNumber int, depth int) error {
 
 // Checkout ...
 func (g *GitClient) Checkout(branch, sha string) error {
-	log.Println("rebasing:", branch, sha)
-	if err := g.command("git", "checkout", "-b", branch, sha).Run(); err != nil {
+	log.Println("checkout:", branch, sha)
+	if err := g.command("git", "checkout", "-b", "pr-"+branch, sha).Run(); err != nil {
 		return fmt.Errorf("checkout failed: %s", err)
 	}
 

--- a/github.go
+++ b/github.go
@@ -351,6 +351,7 @@ func PullRequestFactory(p PullRequestObject) pullrequest.PullRequest {
 		URL:                 p.URL,
 		RepositoryURL:       p.Repository.URL,
 		BaseRefName:         p.BaseRefName,
+		BaseRefOID:          p.BaseRefOID,
 		HeadRefName:         p.HeadRefName,
 		IsCrossRepository:   p.IsCrossRepository,
 		CreatedAt:           p.CreatedAt.Time,

--- a/models.go
+++ b/models.go
@@ -116,6 +116,7 @@ type PullRequestObject struct {
 	Title             string
 	URL               string
 	BaseRefName       string
+	BaseRefOID        string
 	HeadRefName       string
 	IsCrossRepository bool
 	CreatedAt         githubv4.DateTime

--- a/pullrequest/pullrequest.go
+++ b/pullrequest/pullrequest.go
@@ -10,6 +10,7 @@ type PullRequest struct {
 	URL                 string
 	RepositoryURL       string
 	BaseRefName         string
+	BaseRefOID          string
 	HeadRefName         string
 	IsCrossRepository   bool
 	CreatedAt           time.Time

--- a/resource_test.go
+++ b/resource_test.go
@@ -49,6 +49,7 @@ func createTestPR(count int, baseName string, skipCI, isCrossRepo, created, noco
 		Title:             fmt.Sprintf("pr%s title", n),
 		URL:               fmt.Sprintf("pr%s url", n),
 		BaseRefName:       baseName,
+		BaseRefOID:        "sha",
 		HeadRefName:       fmt.Sprintf("pr%s", n),
 		IsCrossRepository: isCrossRepo,
 		CreatedAt:         githubv4.DateTime{Time: c},


### PR DESCRIPTION
- change `checkout` to be default so merge conflicts don't break build
- use PR.BaseRefOID unless rebase or merge
- move metadata properties into function for better testability
- add `-q` to fetch
- fix log entry
- prefix checkout branch with `pr-` to avoid conflicts