### PR TITLE
allow `paths` && `ignore_paths` to be configured simultaneously

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM golang:1.12 as builder
+FROM golang:1.13.1 as builder
 ADD . /go/src/github.com/telia-oss/github-pr-resource
 WORKDIR /go/src/github.com/telia-oss/github-pr-resource
-RUN go get -u -v github.com/go-task/task/cmd/task && task build
+RUN make build
 
 FROM alpine:3.10 as resource
 COPY --from=builder /go/src/github.com/telia-oss/github-pr-resource/build /opt/resource

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+mkfile := $(abspath $(lastword $(MAKEFILE_LIST)))
+dir := $(dir $(ci_mkfile))
+
+BUILD_DIR := build
+DOCKER_REPO := teliaoss/github-pr-resource
+BINARY := check
+EXTENSION :=
+
+GO11MODULE := on
+export GO11MODULE
+
+.PHONY: generate
+generate:
+	@go generate ./...
+
+.PHONY: test
+test: generate
+	@gofmt -s -l -w .
+	@go vet ./...
+	@go test -race -v -cover ./...
+
+.PHONY: e2e
+e2e:
+	@go test -race -v ./... -tags=e2e
+
+.PHONY: docker
+docker:
+	@docker build -t $(DOCKER_REPO):dev .
+
+.PHONY: build
+build: test
+	make go-build BINARY=check --no-print-directory
+	make go-build BINARY=in --no-print-directory
+	make go-build BINARY=out --no-print-directory
+
+.PHONY: go-build
+go-build:
+	@CGO_ENABLED=0 GOOS=${OS} GOOS=${ARCH} go build -o $(BUILD_DIR)/$(BINARY)$(EXTENSION) -ldflags="-s -w" -v cmd/$(BINARY)/main.go
+
+.PHONY: ci
+ci: build
+	@if [ -n "$(git status --porcelain)" ];then echo "Diff in generated files and/or formatting" && exit 1; fi

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Make sure to check out [#migrating](#migrating) to learn more.
 | `access_token`              | Yes      |                                  | A Github Access Token with repository access (required for setting status on commits). N.B. If you want github-pr-resource to work with a private repository. Set `repo:full` permissions on the access token you create on GitHub. If it is a public repository, `repo:status` is enough |
 | `v3_endpoint`               | NO       | `https://api.github.com`         | Endpoint to use for the V3 Github API (Restful) |
 | `v4_endpoint`               | NO       | `https://api.github.com/graphql` | Endpoint to use for the V4 Github API (Graphql) |
-| `paths`                     | No       | `terraform/*/*.tf`               | Only produce new versions if the PR includes changes to files that match one or more glob patterns or prefixes |
-| `ignore_paths`              | No       | `.ci/`                           | Inverse of the above. Pattern syntax is documented in [filepath.Match](https://golang.org/pkg/path/filepath/#Match), or a path prefix can be specified (e.g. `.ci/` will match everything in the `.ci` directory) |
+| `paths`                     | No       | `terraform/**/*.tf`              | Only produce new versions if the PR includes changes to files that match one or more glob patterns using [go-gitignore](https://godoc.org/github.com/sabhiram/go-gitignore) |
+| `ignore_paths`              | No       | `.ci/**/*.yaml`                  | Inverse of the above, all changed files must match in order for the PR to be skipped |
 | `disable_ci_skip`           | No       | `true`                           | Disable ability to skip builds with `[ci skip]` and `[skip ci]` in commit message or pull request title |
 | `skip_ssl_verification`     | No       | `true`                           | Disable SSL/TLS certificate validation on git and API clients. Use with care! |
 | `disable_forks`             | No       | `true`                           | Disable triggering of the resource if the pull request's fork repository is different to the configured repository |
@@ -136,7 +136,6 @@ Note that, should you retrigger a build in the hopes of testing the last commit 
 the base, Concourse will reuse the volume (i.e. not trigger a new `get`) if it still exists, which can produce
 unexpected results (#5). As such, re-testing a PR against a newer version of the base is best done by *pushing an
 empty commit to the PR*.
-
 
 #### `put`
 

--- a/check.go
+++ b/check.go
@@ -49,10 +49,12 @@ func Check(request CheckRequest, manager Github) (CheckResponse, error) {
 			log.Println("changed files found:", p.Files)
 
 			switch {
+			// if `paths` is configured && NONE of the changed files match `paths` pattern/s
 			case pullrequest.Patterns(paths)(p) && !pullrequest.Files(paths, false)(p):
 				log.Println("paths excluded pull")
 				continue
-			case !pullrequest.Patterns(paths)(p) && pullrequest.Patterns(iPaths)(p) && pullrequest.Files(iPaths, true)(p):
+			// if `ignore_paths` is configured && ALL of the changed files match `ignore_paths` pattern/s
+			case pullrequest.Patterns(iPaths)(p) && pullrequest.Files(iPaths, true)(p):
 				log.Println("ignore paths excluded pull")
 				continue
 			}

--- a/go.mod
+++ b/go.mod
@@ -18,3 +18,5 @@ require (
 	golang.org/x/tools v0.0.0-20190829160515-d151469ab045 // indirect
 	google.golang.org/appengine v1.6.2 // indirect
 )
+
+go 1.13

--- a/models.go
+++ b/models.go
@@ -12,20 +12,34 @@ import (
 
 // Source represents the configuration for the resource.
 type Source struct {
-	Repository              string   `json:"repository"`
-	AccessToken             string   `json:"access_token"`
-	V3Endpoint              string   `json:"v3_endpoint"`
-	V4Endpoint              string   `json:"v4_endpoint"`
-	Paths                   []string `json:"paths,omitempty"`
-	IgnorePaths             []string `json:"ignore_paths,omitempty"`
-	DisableCISkip           bool     `json:"disable_ci_skip,omitempty"`
-	SkipSSLVerification     bool     `json:"skip_ssl_verification,omitempty"`
-	DisableForks            bool     `json:"disable_forks,omitempty"`
-	GitCryptKey             string   `json:"git_crypt_key,omitempty"`
-	BaseBranch              string   `json:"base_branch,omitempty"`
-	PreviewSchema           bool     `json:"preview_schema,omitempty"`
-	RequiredReviewApprovals int      `json:"required_review_approvals,omitempty"`
-	Labels                  []string `json:"labels,omitempty"`
+	// Repository to check, get, put
+	Repository string `json:"repository"`
+	// AccessToken for GitHub API with permissions to Repository
+	AccessToken string `json:"access_token"`
+	// V3Endpoint for GitHub Rest API (leave blank for cloud)
+	V3Endpoint string `json:"v3_endpoint"`
+	// V4Endpoint for GitHub GraphQL API (leave blank for cloud)
+	V4Endpoint string `json:"v4_endpoint"`
+	// Paths of Repository to return versions for
+	Paths []string `json:"paths,omitempty"`
+	// IgnorePaths of Repository to skip returning versions for
+	IgnorePaths []string `json:"ignore_paths,omitempty"`
+	// DisableCISkip disables ability to skip CI via PR title / message
+	DisableCISkip bool `json:"disable_ci_skip,omitempty"`
+	// SkipSSLVerification when executing GitHub API requests
+	SkipSSLVerification bool `json:"skip_ssl_verification,omitempty"`
+	// DisableForks disables versions from forks of Repository
+	DisableForks bool `json:"disable_forks,omitempty"`
+	// GitCryptKey enables GitCrypt unlocking
+	GitCryptKey string `json:"git_crypt_key,omitempty"`
+	// BaseBranch returns versions only for matching base branch
+	BaseBranch string `json:"base_branch,omitempty"`
+	// PreviewSchema enables GraphQL preview schemas, see: https://developer.github.com/v4/previews/
+	PreviewSchema bool `json:"preview_schema,omitempty"`
+	// RequiredReviewApprovals returns versions when PR has >= approvals
+	RequiredReviewApprovals int `json:"required_review_approvals,omitempty"`
+	// Labels returns versions for PRs matching labels
+	Labels []string `json:"labels,omitempty"`
 }
 
 // Validate the source configuration.

--- a/models_test.go
+++ b/models_test.go
@@ -82,7 +82,7 @@ func TestMarshalJSON(t *testing.T) {
 			description: "one version",
 			json:        []byte(`[{"pr":"1","commit":"a4afe32","updated":"2019-08-20T00:14:16Z"}]`),
 			versions: []resource.Version{
-				resource.Version{
+				{
 					PR:          1,
 					Commit:      "a4afe32",
 					UpdatedDate: time.Date(2019, time.August, 20, 0, 14, 16, 0, time.UTC),
@@ -93,12 +93,12 @@ func TestMarshalJSON(t *testing.T) {
 			description: "many versions",
 			json:        []byte(`[{"pr":"1","commit":"a4afe32","updated":"2019-08-20T00:14:16Z"},{"pr":"2","commit":"a4afe33","updated":"2020-08-20T00:14:16Z"}]`),
 			versions: []resource.Version{
-				resource.Version{
+				{
 					PR:          1,
 					Commit:      "a4afe32",
 					UpdatedDate: time.Date(2019, time.August, 20, 0, 14, 16, 0, time.UTC),
 				},
-				resource.Version{
+				{
 					PR:          2,
 					Commit:      "a4afe33",
 					UpdatedDate: time.Date(2020, time.August, 20, 0, 14, 16, 0, time.UTC),

--- a/out.go
+++ b/out.go
@@ -11,28 +11,31 @@ import (
 
 // Put (business logic)
 func Put(request PutRequest, manager Github, inputDir string) (*PutResponse, error) {
-	if err := request.Params.Validate(); err != nil {
+	err := request.Params.Validate()
+	if err != nil {
 		return nil, fmt.Errorf("invalid parameters: %s", err)
 	}
 	path := filepath.Join(inputDir, request.Params.Path, ".git", "resource")
 
 	// Version available after a GET step.
 	var version Version
-	content, err := ioutil.ReadFile(filepath.Join(path, "version.json"))
+	b, err := readFile("version", path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read version from path: %s", err)
+		return nil, err
 	}
-	if err := json.Unmarshal(content, &version); err != nil {
+	err = json.Unmarshal(b, &version)
+	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal version from file: %s", err)
 	}
 
 	// Metadata available after a GET step.
 	var metadata Metadata
-	content, err = ioutil.ReadFile(filepath.Join(path, "metadata.json"))
+	b, err = readFile("metadata", path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read metadata from path: %s", err)
+		return nil, err
 	}
-	if err := json.Unmarshal(content, &metadata); err != nil {
+	err = json.Unmarshal(b, &metadata)
+	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal metadata from file: %s", err)
 	}
 
@@ -70,6 +73,15 @@ func Put(request PutRequest, manager Github, inputDir string) (*PutResponse, err
 		Version:  version,
 		Metadata: metadata,
 	}, nil
+}
+
+func readFile(name, path string) ([]byte, error) {
+	content, err := ioutil.ReadFile(filepath.Join(path, name+".json"))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s from path: %s", name, err)
+	}
+
+	return content, nil
 }
 
 // PutRequest ...

--- a/pullrequest/filter.go
+++ b/pullrequest/filter.go
@@ -204,16 +204,18 @@ func Files(patterns []string, invert bool) Filter {
 
 		for _, f := range p.Files {
 			log.Println("comparing patterns to changed file:", f)
-			if gc.MatchesPath(f) {
+			if gc.MatchesPath("/" + f) {
 				if !invert {
-					log.Println("paths: true")
+					log.Println("paths: true -", "matched:", f)
 					return true
 				}
 
 				matched = append(matched, 1)
+				log.Println("matched:", f)
 			}
 		}
 
+		log.Println("invert:", invert, "- matched:", len(matched), "- files:", len(p.Files))
 		if invert && len(matched) == len(p.Files) {
 			log.Println("ignore paths: true")
 			return true

--- a/pullrequest/functional_test.go
+++ b/pullrequest/functional_test.go
@@ -405,8 +405,8 @@ func TestBuildCI(t *testing.T) {
 			description: "match v1",
 			pull: pullrequest.PullRequest{
 				Comments: []pullrequest.Comment{
-					pullrequest.Comment{Body: "weeee I don't want to build ci"},
-					pullrequest.Comment{Body: "weeee I do want to [build ci]"},
+					{Body: "weeee I don't want to build ci"},
+					{Body: "weeee I do want to [build ci]"},
 				},
 			},
 			expect: true,
@@ -415,8 +415,8 @@ func TestBuildCI(t *testing.T) {
 			description: "match v2",
 			pull: pullrequest.PullRequest{
 				Comments: []pullrequest.Comment{
-					pullrequest.Comment{Body: "weeee I don't want to build ci"},
-					pullrequest.Comment{Body: "weeee I do want to [ci build]"},
+					{Body: "weeee I don't want to build ci"},
+					{Body: "weeee I do want to [ci build]"},
 				},
 			},
 			expect: true,
@@ -425,7 +425,7 @@ func TestBuildCI(t *testing.T) {
 			description: "no match",
 			pull: pullrequest.PullRequest{
 				Comments: []pullrequest.Comment{
-					pullrequest.Comment{Body: "weeee I don't want to build ci"},
+					{Body: "weeee I don't want to build ci"},
 				},
 			},
 			expect: false,
@@ -450,7 +450,7 @@ func TestBaseRefChanged(t *testing.T) {
 			description: "match single",
 			pull: pullrequest.PullRequest{
 				Events: []pullrequest.Event{
-					pullrequest.Event{
+					{
 						Type:      pullrequest.BaseRefChangedEvent,
 						CreatedAt: time.Now(),
 					},
@@ -462,11 +462,11 @@ func TestBaseRefChanged(t *testing.T) {
 			description: "match many",
 			pull: pullrequest.PullRequest{
 				Events: []pullrequest.Event{
-					pullrequest.Event{
+					{
 						Type:      pullrequest.BaseRefForcePushedEvent,
 						CreatedAt: time.Now(),
 					},
-					pullrequest.Event{
+					{
 						Type:      pullrequest.BaseRefChangedEvent,
 						CreatedAt: time.Now(),
 					},
@@ -478,7 +478,7 @@ func TestBaseRefChanged(t *testing.T) {
 			description: "no match",
 			pull: pullrequest.PullRequest{
 				Events: []pullrequest.Event{
-					pullrequest.Event{
+					{
 						Type:      pullrequest.BaseRefForcePushedEvent,
 						CreatedAt: time.Now(),
 					},
@@ -506,7 +506,7 @@ func TestBaseRefForcePushed(t *testing.T) {
 			description: "match single",
 			pull: pullrequest.PullRequest{
 				Events: []pullrequest.Event{
-					pullrequest.Event{
+					{
 						Type:      pullrequest.BaseRefForcePushedEvent,
 						CreatedAt: time.Now(),
 					},
@@ -518,19 +518,19 @@ func TestBaseRefForcePushed(t *testing.T) {
 			description: "match many",
 			pull: pullrequest.PullRequest{
 				Events: []pullrequest.Event{
-					pullrequest.Event{
+					{
 						Type:      pullrequest.HeadRefForcePushedEvent,
 						CreatedAt: time.Now(),
 					},
-					pullrequest.Event{
+					{
 						Type:      pullrequest.HeadRefForcePushedEvent,
 						CreatedAt: time.Now(),
 					},
-					pullrequest.Event{
+					{
 						Type:      pullrequest.BaseRefChangedEvent,
 						CreatedAt: time.Now(),
 					},
-					pullrequest.Event{
+					{
 						Type:      pullrequest.BaseRefForcePushedEvent,
 						CreatedAt: time.Now(),
 					},
@@ -542,7 +542,7 @@ func TestBaseRefForcePushed(t *testing.T) {
 			description: "no match",
 			pull: pullrequest.PullRequest{
 				Events: []pullrequest.Event{
-					pullrequest.Event{
+					{
 						Type:      pullrequest.BaseRefChangedEvent,
 						CreatedAt: time.Now(),
 					},
@@ -570,7 +570,7 @@ func TestHeadRefForcePushed(t *testing.T) {
 			description: "match single",
 			pull: pullrequest.PullRequest{
 				Events: []pullrequest.Event{
-					pullrequest.Event{
+					{
 						Type:      pullrequest.HeadRefForcePushedEvent,
 						CreatedAt: time.Now(),
 					},
@@ -582,19 +582,19 @@ func TestHeadRefForcePushed(t *testing.T) {
 			description: "match many",
 			pull: pullrequest.PullRequest{
 				Events: []pullrequest.Event{
-					pullrequest.Event{
+					{
 						Type:      pullrequest.HeadRefForcePushedEvent,
 						CreatedAt: time.Now(),
 					},
-					pullrequest.Event{
+					{
 						Type:      pullrequest.HeadRefForcePushedEvent,
 						CreatedAt: time.Now(),
 					},
-					pullrequest.Event{
+					{
 						Type:      pullrequest.BaseRefChangedEvent,
 						CreatedAt: time.Now(),
 					},
-					pullrequest.Event{
+					{
 						Type:      pullrequest.BaseRefForcePushedEvent,
 						CreatedAt: time.Now(),
 					},
@@ -606,7 +606,7 @@ func TestHeadRefForcePushed(t *testing.T) {
 			description: "no match",
 			pull: pullrequest.PullRequest{
 				Events: []pullrequest.Event{
-					pullrequest.Event{
+					{
 						Type:      pullrequest.BaseRefForcePushedEvent,
 						CreatedAt: time.Now(),
 					},
@@ -634,7 +634,7 @@ func TestReopened(t *testing.T) {
 			description: "match single",
 			pull: pullrequest.PullRequest{
 				Events: []pullrequest.Event{
-					pullrequest.Event{
+					{
 						Type:      pullrequest.ReopenedEvent,
 						CreatedAt: time.Now(),
 					},
@@ -646,19 +646,19 @@ func TestReopened(t *testing.T) {
 			description: "match many",
 			pull: pullrequest.PullRequest{
 				Events: []pullrequest.Event{
-					pullrequest.Event{
+					{
 						Type:      pullrequest.HeadRefForcePushedEvent,
 						CreatedAt: time.Now(),
 					},
-					pullrequest.Event{
+					{
 						Type:      pullrequest.HeadRefForcePushedEvent,
 						CreatedAt: time.Now(),
 					},
-					pullrequest.Event{
+					{
 						Type:      pullrequest.ReopenedEvent,
 						CreatedAt: time.Now(),
 					},
-					pullrequest.Event{
+					{
 						Type:      pullrequest.BaseRefForcePushedEvent,
 						CreatedAt: time.Now(),
 					},
@@ -670,7 +670,7 @@ func TestReopened(t *testing.T) {
 			description: "no match",
 			pull: pullrequest.PullRequest{
 				Events: []pullrequest.Event{
-					pullrequest.Event{
+					{
 						Type:      pullrequest.HeadRefForcePushedEvent,
 						CreatedAt: time.Now(),
 					},
@@ -759,25 +759,49 @@ func TestFiles(t *testing.T) {
 			expect: true,
 		},
 		{
-			description: "match /**/*",
-			patterns:    []string{"docode/src/do/teams/cns/network/ha-agent/**/*"},
+			description: "no match /**/*",
+			patterns:    []string{"/ci/**/*"},
 			invert:      false,
 			pull: pullrequest.PullRequest{
 				Files: []string{
-					"docode/src/do/teams/cns/network/ha-agent/README.md",
-					"docode/src/do/teams/cns/network/ha-agent/ci/pipeline.yml",
+					"src/teams/myteam/README.md",
+					"src/teams/myteam/ci/pipeline.yml",
+				},
+			},
+			expect: false,
+		},
+		{
+			description: "match /**/*",
+			patterns:    []string{"/ci/**/*"},
+			invert:      false,
+			pull: pullrequest.PullRequest{
+				Files: []string{
+					"ci/README.md",
+					"ci/pipeline.yml",
+				},
+			},
+			expect: true,
+		},
+		{
+			description: "match **/*",
+			patterns:    []string{"src/teams/myteam/**/*"},
+			invert:      false,
+			pull: pullrequest.PullRequest{
+				Files: []string{
+					"src/teams/myteam/README.md",
+					"src/teams/myteam/ci/pipeline.yml",
 				},
 			},
 			expect: true,
 		},
 		{
 			description: "match multiple files 2",
-			patterns:    []string{"docode/src/do/teams/cns/network/ha-agent/**/*", "docode/src/do/teams/cns/network/ha-agent/*"},
+			patterns:    []string{"src/teams/myteam/**/*", "src/teams/myteam/*"},
 			invert:      false,
 			pull: pullrequest.PullRequest{
 				Files: []string{
-					"docode/src/do/teams/cns/network/ha-agent/README.md",
-					"docode/src/do/teams/cns/network/ha-agent/ci/pipeline.yml",
+					"src/teams/myteam/README.md",
+					"src/teams/myteam/ci/pipeline.yml",
 				},
 			},
 			expect: true,


### PR DESCRIPTION
- update go to 1.13.1
- consolidate file i/o code
- add GoDoc comments to configuration vars
- swap `go-task` for GNU Make due to go1.13 incompatibility