### PR TITLE
limit query to searched events

### DIFF
--- a/models.go
+++ b/models.go
@@ -186,7 +186,7 @@ type PullRequestObject struct {
 				} `graphql:"... on PullRequestCommit"`
 			}
 		}
-	} `graphql:"timelineItems(last:100,since:$s)"`
+	} `graphql:"timelineItems(last:100,since:$s,itemTypes:[BASE_REF_CHANGED_EVENT,BASE_REF_FORCE_PUSHED_EVENT,HEAD_REF_FORCE_PUSHED_EVENT,ISSUE_COMMENT,REOPENED_EVENT])"`
 }
 
 // CommitObject represents the GraphQL commit node.


### PR DESCRIPTION
GHE v2.17 supports draft prs in the GUI but not the API, which is a bug. This leads to the API failing on all queries that include a PR with the `READY_FOR_REVIEW ` event. Limiting the events in the query to only the ones we care about prevents the request from failing.