### PR TITLE
Make checked out branch prefix optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Make sure to check out [#migrating](#migrating) to learn more.
 | `preview_schema`            | No       | `true`                           | if enabled, an `Accept: application/vnd.github.starfire-preview+json` header will be appended to each request to enable preview schema's that are hidden behind a feature flag on GitHub |
 | `required_review_approvals` | No       | `2`                              | Disable triggering of the resource if the pull request does not have at least `X` approved review(s) |
 | `labels`                    | No       | `["bug", "enhancement"]`         | The labels on the PR. The pipeline will only trigger on pull requests having at least one of the specified labels |
+| `checkout_branch_prefix`    | No       |  pre-                            | A prefix to add to the name of the checked out branch, defaults to empty string. If it is not set explicitly in `Source` definition, the resource will just checkout the remote branch wihtout creating any new local branch
 
 Notes:
  - If `v3_endpoint` is set, `v4_endpoint` must also be set (and the other way around).

--- a/git.go
+++ b/git.go
@@ -34,17 +34,19 @@ func NewGitClient(source *Source, dir string, output io.Writer) (*GitClient, err
 		os.Setenv("GIT_SSL_NO_VERIFY", "true")
 	}
 	return &GitClient{
-		AccessToken: source.AccessToken,
-		Directory:   dir,
-		Output:      output,
+		AccessToken:          source.AccessToken,
+		Directory:            dir,
+		Output:               output,
+		CheckoutBranchPrefix: source.CheckOutBranchPrefix,
 	}, nil
 }
 
 // GitClient ...
 type GitClient struct {
-	AccessToken string
-	Directory   string
-	Output      io.Writer
+	AccessToken          string
+	Directory            string
+	Output               io.Writer
+	CheckoutBranchPrefix string
 }
 
 func (g *GitClient) command(name string, arg ...string) *exec.Cmd {
@@ -170,7 +172,7 @@ func (g *GitClient) Fetch(prNumber, depth int) error {
 // Checkout ...
 func (g *GitClient) Checkout(branch, sha string) error {
 	log.Println("checkout:", branch, sha)
-	if err := g.command("git", "checkout", "-b", "pr-"+branch, sha).Run(); err != nil {
+	if err := g.command("git", "checkout", "-b", g.CheckoutBranchPrefix+branch, sha).Run(); err != nil {
 		return fmt.Errorf("checkout failed: %s", err)
 	}
 

--- a/models.go
+++ b/models.go
@@ -40,6 +40,8 @@ type Source struct {
 	RequiredReviewApprovals int `json:"required_review_approvals,omitempty"`
 	// Labels returns versions for PRs matching labels
 	Labels []string `json:"labels,omitempty"`
+	// Prefix added to the checked out branch, it is optional, and defaults to empty string
+	CheckOutBranchPrefix string `json:"checkout_branch_prefix,omitempty"`
 }
 
 // Validate the source configuration.


### PR DESCRIPTION
Adding the `pr-` prefix to the name of the checked out branch creates a new branch which does not exist in the remote repository. To avoid using a hardcoded prefix in the checked out branch, this PR adds a `checkout_branch_prefix` parameter to `Source` configuration. It is optional, and defaults to empty string. If a prefix is needed, it should be passed in the `source` definition of concourse resource type as example:

```
resources:
- name: pull-request
  type: pull-request
  source:
    repository: itsdalmo/test-repository
    access_token: ((github-access-token)
    checkout_branch_prefix: pre-

```